### PR TITLE
Bugfix: set the property variables instead of the parameter variables

### DIFF
--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -65,8 +65,8 @@ class TelemetryEventImpl implements TelemetryEvent {
 		private properties?: TelemetryEventProperties,
 		private measurements?: TelemetryEventMeasures)
 	{
-		properties = properties || { };
-		measurements = measurements || { };
+		this.properties = properties || { };
+		this.measurements = measurements || { };
 	}
 
 	public send(): void {


### PR DESCRIPTION
Fixes a bug where the wrong variable would be set in the TelemetryEvent constructor.  Apparently, when you define a property inline with the constructor signature, it immediately splits that parameter into two independent variables: one for the property (`this.measurements`) and one as a parameter (just `measurements`).  Since they're immediately separate variables, setting one doesn't affect the other.

Reduced PoC:

https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgCoQDYQLYTFATwFEA3CcABSgHsAHaMYCAZ2QG8AoASAG0BrCAQBcyZvlABzALoixUSQG4OAXw4dQkWIhTosufMTLgAshDjMArlBbtu-QbPEhpIkBewAjaEtXrw0eCQ0TBw8QlJyMFsuZnIAEwAKAEoREmpgOKUuAHdgMAALAEE4uLzgahA4DCo6BiZmBLgSsoqqmvooRhYRXVCDCMoaDq7mFOC9MMNIrNyC4tLGVoxTcytQ8AamhfLK5bNLa1wNnpD9cKMwFYOWMd6zqfAfNQQMc1Y7yYGwAElsWgxoggKnILAgwNQoAluFxaPISHBIMgIBcAHJwXCOeTOAA00NhwHhiNhtU69QA-CcJv0Lu06ixcVwYXCEShcKtDpFmBTxn1zpErmtRtxOIyCsBmAA6YnDerIAC8yDFkuldNYAB81exkMoslwAPR6oEgZjULASjDUCQJADkABEiAAhACqAHFkIURNbkABqZBs65HMCjXX+taB1gK0McjbIDVanXQg1Gk1mi1Wu2O13IB2en1+-ZhzlJLK+ZBl5C0CweDDABDIWZFZqLXa00ksRpNnZtIaqym8h5gVsjW6nT4XaJcADyHgAVhAwRK3sAJCAEkqpT228xscgti0W5vh7rrGArCBFflxSW1DCqzW6w35vuqgLo0GO9slq-1kG+-cvt+ox-mOkS2ImhrAqaEDmpaNr2s6boAMK5r665Rj+wbQtOc4LkuK5rpekroeGO57s2L4Fm+mGMieZ4Xle3CluWlbVrWojxMkqTpHEE7JlBMFWgABgAJGw67IpEaK4MoQgADogPJyDtMwQiieuKpbsoyDyYpgEiGphESsRnLKIJxaMSozyvMw7yjgYABKEC0BCmiAsC+CguCkJJNEvi3qxdYINYLIAGpMNkXwJCQ4WYpII5Uny4ATrRUDniAEDZDy-4XL8-w2tFGXWjuIqMgV2SpOF0LKOZXB+Sx97IEFZiQIUYI7JFZWxTiu5tRUXUSDuYBwFAEh4P18rINaRWiNQVhIONCpTTucRWAiOzfCAxhcq47heFA8X9l8vHufm7LdB81L8pRNgKitUBrRUG1bcgZJandD0gE9KnIO9zZfdqyAiGw2rHngdHpZlF2JT8fwYDaiDNl800lVwnXIGVDKMgjOwiNjFSY1wQ0jWNirDaNYAEyac0QLIs1QEgVU7uh1F1XebFNSypjiAgzCRWctbfVDA6ATuEg0BYtBSTTohOBIE1TQd2WgSVKVpRlWUgeAuVw9a-M80jxVi7NkvotLRsS1LyhM2EAs1azAWNcFkBEFANBQB1MUy1iA3IJUGJe5IO7QG7iHUHE0tyJI8vTcHEKoAQ9ALZN1qK5rUQq2DqW++rQtfNrNqx+7FzI9CqOexjpd+9LVcE4XofhyIddhxAteu3HCfS4X8f0FVds3vV7NOxAucXAkEngFL-U7hpIzciPkRDvU1tneGc92dDgGp5dSUZ6eWcQxr28w3l49gFL0+Hkvp0BkW16+MmURRAqB9C45zmdNAyRKBwBjRGAEocxar1EAkVrRlWmtaPGIAU7QglI+TsX5rrhgSGwdCIgAAM1VuB8VTLBSBwCvgiEACjkMDVAIARAgfIY9XY+RFDg6CaZ4YEIuChJENCng-0IH-ABQ8XZu1AeAnc+DmwwMZHAvIjZPy7G-Mg1B10MFYK4PQgSBc25F0iMQ0hHByFgEodQ-abljT8UYdaQuhDJp5mDuZXwv8RT-0ARAMKGUBHhVEVwcRcwEHSKQZyFBaDkCYKSNgyCuD0xlXMSQoJZCKFUKsYYlMDC8HhJYRY30ViOG2O4PYoeXN5D61HmwascB8hCAAIyKPcfAqRFEV6+LkWdBRQSlEhMSemPWvMUmRMsjovRcS6EtJUbrG2+SNGpLYftHwQA