### PR TITLE
Set version to extension version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/ads-extension-telemetry",
   "description": "A module for first party Microsoft extensions to report consistent telemetry.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Currently the version field is auto-populated by the 1DS library with some string similar to `PostChannel=3.2.6`. Overwriting that with the extension version to match the behavior of ADS. 