### PR TITLE
Add serverInfo and sync with core ADS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/ads-extension-telemetry",
   "description": "A module for first party Microsoft extensions to report consistent telemetry.",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "author": {
     "name": "Microsoft Corporation"
   },
@@ -21,7 +21,7 @@
     "@vscode/extension-telemetry": "0.6.1"
   },
   "devDependencies": {
-    "@types/azdata": "^1.29.0",
+    "@types/azdata": "^1.41.0",
     "@types/node": "^8.0.24",
     "standard-version": "^9.3.0",
     "typescript": "4.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@types/azdata@^1.29.0":
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/@types/azdata/-/azdata-1.29.0.tgz#0fa3e6d6ae7130babf6bc9e40781a01541622c76"
-  integrity sha512-KExDgLBV+HxHwy7YASwAw7l8bHd5Xl0MjB53j5YubJgQU/vsll+qn2U+MRegIhCy05bstQV/Tat1lIrtsf0CnA==
+"@types/azdata@^1.41.0":
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/@types/azdata/-/azdata-1.41.0.tgz#503d7d6a9c4aa719d05aa39a33aa76eaed8334fc"
+  integrity sha512-6mw3UyZVirk5iTMNIwuv5TLr0SUxiHTmYnYieAPNakWJwz+gY+ZleoDrCQq7wnHyUMXFcZN5y2Z7kWUMuOdcWg==
   dependencies:
     "@types/vscode" "*"
 


### PR DESCRIPTION
Noticed that we didn't have withServerInfo here so adding that, and also fixing withConnectionInfo (connection info doesn't have the server properties we were using anyways). 

Along with this removed the custom interface definitions - it's easier just to directly use the types we expect them to be anyways. 

This will line it up with the implement in ADS core, which is generally what we want to be doing anyways. 