### PR TITLE
Redact error message from stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/ads-extension-telemetry",
   "description": "A module for first party Microsoft extensions to report consistent telemetry.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -309,7 +309,13 @@ export default class TelemetryReporter<V extends string = string, A extends stri
 		};
 		if (error instanceof Error) {
 			props.message = includeMessage === true ? error.message : '';
-			props.stack = error.stack || ''
+			let stack = error.stack || '';
+			// Stack trace contains the message, so remove it if we aren't set to include it
+			if (includeMessage !== true && error.message) {
+				const regex = new RegExp(error.message, 'g');
+				stack = stack.replace(regex, '<REDACTED: error-message>')
+			}
+			props.stack = stack;
 		} else {
 			props.message = includeMessage === true ? error?.toString() : '';
 			props.stack = '';


### PR DESCRIPTION
Stack traces also have the error message in them, so for now we need to redact that as well if the user didn't opt in to including the message.