### PR TITLE
Remove azdata types from exported functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/ads-extension-telemetry",
   "description": "A module for first party Microsoft extensions to report consistent telemetry.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
This package can be used in VS Code, so to avoid having to have those extensions add the ADS package we create our own type and export that instead. 

Also fixed up the logic to prevent against invalid objects being passed in (in case someone uses any or something to ignore the typings or is using JS directly) just to be on the safe side. Not something I expect to happen (and if it does that's on the caller), but want to add at least a few basic checks to prevent common issues. 